### PR TITLE
Rename control.msg to control.cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The effect of disconnect on a worker is to close all the servers in the worker,
 wait for them to close, and then exit. This process may not occur in a timely
 fashion if, for example, the server connections do not close. In order to
 gracefully close any open connections, a worker may listen to the `SHUTDOWN`
-message, see `control.msg.SHUTDOWN`.
+message, see `control.cmd.SHUTDOWN`.
 
 Sends a `SHUTDOWN` message to the identified worker, calls
 `worker.disconnect()`, and sets a timer for `control.options.shutdownTimeout`.
@@ -202,7 +202,7 @@ The options set by calling `.start()`.
 Visible for diagnostic and logging purposes, do *not* modify the options
 directly.
 
-### control.msg.SHUTDOWN
+### control.cmd.SHUTDOWN
 
 * {String} `'CLUSTER_CONTROL_shutdown'`
 
@@ -217,13 +217,13 @@ been completed.
 
 The message format is:
 
-    { cmd: control.msg.SHUTDOWN }
+    { cmd: control.cmd.SHUTDOWN }
 
 It can be received in a worker by listening for a `'message'` event with a
 matching `cmd` property:
 
     process.on('message', function(msg) {
-        if(msg.cmd === control.msg.SHUTDOWN) {
+        if(msg.cmd === control.cmd.SHUTDOWN) {
             // Close any open connections as soon as they are idle...
         }
     });

--- a/index.js
+++ b/index.js
@@ -26,5 +26,5 @@ if (cluster.isMaster) {
       process.nextTick(callback);
     }
   };
-  exports.msg = require('./lib/msg');
+  exports.cmd = require('./lib/msg');
 }

--- a/lib/master.js
+++ b/lib/master.js
@@ -34,7 +34,7 @@ master.start = start;
 master.stop = stop;
 master.ADDR = ctl.ADDR;
 master.CPUS = os.cpus().length;
-master.msg = msg;
+master.cmd = msg;
 
 function request(req, callback) {
   debug('master - request', req);

--- a/lib/msg.js
+++ b/lib/msg.js
@@ -1,4 +1,4 @@
-// msg: definition of message names
+// msg: definition of cmd names used for messages
 
 var prefix = 'CLUSTER_CONTROL_';
 

--- a/test/master.js
+++ b/test/master.js
@@ -51,6 +51,10 @@ describe('master', function() {
     assert.equal(master.CPUS, os.cpus().length);
   });
 
+  it('should expose message cmd names in master', function() {
+    assert.equal(master.cmd.SHUTDOWN, 'CLUSTER_CONTROL_shutdown');
+  });
+
   it('should report status array for 0 workers', function(done) {
     master.request({cmd:'status'}, function(rsp) {
       assert.deepEqual(rsp, {workers:[]});

--- a/test/workers/null.js
+++ b/test/workers/null.js
@@ -55,9 +55,9 @@ function shutdownGracefully() {
   });
   process.on('message', function(msg) {
     debug('worker, message', msg,
-          'shutdown?', control.msg.SHUTDOWN,
+          'shutdown?', control.cmd.SHUTDOWN,
           'connections=', connections.length);
-    if(msg.cmd === control.msg.SHUTDOWN) {
+    if(msg.cmd === control.cmd.SHUTDOWN) {
       connections.forEach(function(conn) {
         debug('worker says bye to peer', conn.remotePort);
         conn.end('bye');


### PR DESCRIPTION
Its a more obvious name.

/to @bajtos 

Also, only the name in worker was being unit tested. Oops. Now both are tested.
