### PR TITLE
Windows control port defaults to localhost:8765

### DIFF
--- a/lib/ctl.js
+++ b/lib/ctl.js
@@ -12,7 +12,7 @@ var util = require('util');
 var cmd = require('./cmd');
 var debug = require('./debug');
 
-var ADDR = 'clusterctl';
+var ADDR = require('./platform').isWindows ? 8765 : 'clusterctl';
 var server;
 var unlinkAddr;
 
@@ -36,7 +36,7 @@ function start(master, options) {
 
   unlinkAddr();
 
-  net.createServer({allowHalfOpen: true}, function (sock) {
+  var _server = net.createServer({allowHalfOpen: true}, function (sock) {
     debug('ctl - accept connection', sock.remoteAddress);
     master.emit('connection', sock);
 
@@ -57,11 +57,23 @@ function start(master, options) {
     master.emit('error', er);
   }).on('close', function() {
     server = undefined;
-  }).listen(addr, function () {
-    server = this; // because it isn't valid to close a server until it is listening
-    debug('ctl - listen on', server.address());
-    master.emit('listening', this);
   });
+
+  try {
+    if(process.env.DEBUG_WIN32 && Object.prototype.toString.call(addr) === '[object String]') {
+      throw Error('listen on a string would fail on win32');
+    }
+    // listen() throws errors... emit them for consistency.
+    _server.listen(addr, function () {
+      server = this; // because it isn't valid to close a server until it is listening
+      debug('ctl - listen on', server.address());
+      master.emit('listening', this);
+    });
+  } catch(er) {
+    process.nextTick(function() {
+      _server.emit('error', er);
+    });
+  }
 
   process.once('exit', unlinkAddr);
 }

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1,0 +1,7 @@
+// For simulating windows behaviours on unix, this defines isWindows
+// if we are are on windows, or have DEBUG_WIN32 set in the environment.
+if(process.platform === 'win32' || process.env.DEBUG_WIN32) {
+  exports.isWindows = true;
+} else {
+  exports.isWindows = false;
+}

--- a/test/control.js
+++ b/test/control.js
@@ -5,6 +5,7 @@ var path = require('path');
 
 var client = require('../lib/client');
 var ctl = require('../lib/ctl');
+var util = require('./util');
 
 describe('client', function() {
   it('should expose default socket address', function() {
@@ -73,7 +74,7 @@ describe('control channel', function() {
     });
   });
 
-  it('should listen on specific path', function(done) {
+  util.onUnixIt('should listen on specific path', function(done) {
     var master = new EventEmitter();
     ctl.start(master, {addr:'_ctl'});
 

--- a/test/master.js
+++ b/test/master.js
@@ -7,6 +7,7 @@ var path = require('path');
 var client = require('../lib/client');
 var debug = require('../lib/debug');
 var master = require('../lib/master');
+var util = require('./util');
 
 debug('master', process.pid);
 
@@ -44,7 +45,8 @@ describe('master', function() {
   });
 
   it('should expose default socket address', function() {
-    assert.equal(master.ADDR, 'clusterctl');
+    var addr = util.isWindows ? 8765 : 'clusterctl';
+    assert.equal(master.ADDR, addr);
   });
 
   it('should expose cpu count, for easy use as a default size', function() {
@@ -121,7 +123,7 @@ describe('master', function() {
     });
   });
 
-  it('should start on path', function(done) {
+  util.onUnixIt('should start on path', function(done) {
     master.start({path:'_ctl'});
     master.once('start', connect);
 

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,10 @@
+var isWindows = exports.isWindows = require('../lib/platform').isWindows;
+
+// specialize of mocha's it() for unix-only shoulds.
+exports.onUnixIt = function onUnixIt(name, callback) {
+  if(isWindows) {
+    it.skip(name,callback);
+  } else {
+    it(name,callback);
+  }
+}


### PR DESCRIPTION
To ease testing of the windows code on unix, I implemented unix
simulation of what happens on windows, particularly of what happens when
you try to listen() on a path (an error is thrown). Some tests depend on
unix support, they are now skipped conditionally depending on the
platform.

/to @Schoonology After this, two tests still fail, ones having to do with subtleties of cluster worker signal handling, and it doesn't really surprise me that there is a platform dependency there. I don't have time to trace down why on windows right now, though.
