### PR TITLE
Add master.status(), a public method for cluster state.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ The combination of the above three allows you to determine if you are a worker,
 or not, and if you are a master, if you should start the cluster control module,
 or just start the server if clustering was not requested.
 
+### control.status()
+
+Returns the current cluster status similar to what's sent to
+`clusterctl status`. Its properties include:
+
+ - `workers`: {Array} An Array of Objects containining the following properties:
+    - `id`: The id of the Worker within the Master.
+    - `pid`: The pid of the Worker process.
 
 ### control.setSize(N)
 

--- a/lib/master.js
+++ b/lib/master.js
@@ -23,6 +23,7 @@ var OPTION_DEFAULTS = {
 };
 
 master.request = request; // XXX(sam) not public, should be master._request
+master.status = status;
 master.setSize = setSize;
 master._resize = resize;
 master._startOne = startOne;
@@ -45,16 +46,7 @@ function request(req, callback) {
   };
 
   if(cmd === 'status') {
-    rsp.workers = [];
-
-    for (var id in cluster.workers) {
-      var w = cluster.workers[id];
-      rsp.workers.push({
-        id: id,
-        pid: w.process.pid,
-      });
-    }
-
+    rsp = master.status();
   } else if(cmd === 'set-size') {
     try {
       master.setSize(req.size);
@@ -81,7 +73,23 @@ function request(req, callback) {
   return this;
 }
 
-// XXX how to check for properly formed int?
+function status() {
+  var retval = {};
+
+  retval.workers = [];
+
+  for (var id in cluster.workers) {
+    var w = cluster.workers[id];
+    retval.workers.push({
+      id: id,
+      pid: w.process.pid,
+    });
+  }
+
+  return retval;
+}
+
+// TODO(schoon) - Check for valid size with `typeof`, et al or use `is2`.
 function setSize(size) {
   var self = this;
 

--- a/test/master.js
+++ b/test/master.js
@@ -55,11 +55,10 @@ describe('master', function() {
     assert.equal(master.cmd.SHUTDOWN, 'CLUSTER_CONTROL_shutdown');
   });
 
-  it('should report status array for 0 workers', function(done) {
-    master.request({cmd:'status'}, function(rsp) {
-      assert.deepEqual(rsp, {workers:[]});
-      done();
-    });
+  it('should report status array for 0 workers', function() {
+    var rsp = master.status();
+
+    assert.deepEqual(rsp, {workers:[]});
   });
 
   it('should report status array for 1 workers', function(done) {


### PR DESCRIPTION
Previously, you had to either know too much or use request (which
could be argued is still knowing about and being concerned with too
much of the internals of cluster-control).

/to @sam-github 
