### PR TITLE
start/stop stubs for worker return an EventEmitter

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ if (cluster.isMaster) {
   module.exports.VERSION = VERSION;
   cluster._strongControlMaster = module.exports;
 } else {
+  exports = module.exports = new (require('events').EventEmitter);
   // Calling .start() in a worker is a nul op
   exports.start = function (options, callback) {
     // both options and callback are optional, adjust position based on type
@@ -35,11 +36,13 @@ if (cluster.isMaster) {
     if(callback) {
       process.nextTick(callback);
     }
+    return this;
   };
   exports.stop = function(callback) {
     if(callback) {
       process.nextTick(callback);
     }
+    return this;
   };
   exports.cmd = require('./lib/msg');
   exports.loadOptions = require('./lib/load-options');

--- a/test/master.js
+++ b/test/master.js
@@ -63,6 +63,15 @@ describe('master', function() {
       assert.equal(master.cmd.SHUTDOWN, 'CLUSTER_CONTROL_shutdown');
     });
 
+    it('stub of start/stop in worker', function(done) {
+      cluster.fork({
+        cmd: 'TEST-API-STUB'
+      }).on('exit', function(code) {
+        assert.equal(code, 0);
+        return done();
+      });
+    });
+
   });
 
   describe('should report status array', function() {

--- a/test/workers/null.js
+++ b/test/workers/null.js
@@ -9,6 +9,8 @@ var debug = require('../../lib/debug');
 
 debug('worker start', cluster.worker.id, 'pid', process.pid, process.argv, 'cmd:', process.env.cmd);
 
+testApiStub();
+
 assert(!cluster.isMaster);
 
 onCommand(process.env);
@@ -39,6 +41,9 @@ function onCommand(msg) {
   }
   if(msg.cmd === 'ERROR') {
     throw Error('On command, I error!');
+  }
+  if(msg.cmd === 'TEST-API-STUB') {
+    testApiStub();
   }
 }
 
@@ -130,4 +135,15 @@ function makeBusy(callback) {
       });
   }
   return server;
+}
+
+function testApiStub() {
+  control.start({
+    size: control.CPUS
+  }).on('error', function(er) {
+  }).stop(function () {
+  }).once('error', function() {
+  });
+
+  process.exit();
 }


### PR DESCRIPTION
This change makes the example usage at the top of the README valid again.

SLN-651
