### PR TITLE
Install CLI as sl-clusterctl

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   ],
   "main": "index.js",
   "bin": {
-    "clusterctl": "bin/cli.js"
+    "clusterctl": "bin/cli.js",
+    "sl-clusterctl": "bin/cli.js"
   },
   "scripts": {
     "test": "mocha --reporter spec",


### PR DESCRIPTION
This is for consistency with strongloop toolbox naming, and to allow
integration as an slc/strong-cli sub-command.
