### PR TITLE
PoC: remote cluster control using ssh2

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -28,6 +28,7 @@ function cli(argv, version, cb) {
 
   program
   .option('-p,--path,--port <path>', 'name of control socket, defaults to ' + client.ADDR)
+  .option('-r,--remote <ssh-user@ssh-host>', 'remote server where strong-cluster-control socket is')
   ;
 
   program
@@ -99,7 +100,7 @@ function cli(argv, version, cb) {
 
   program.parse(argv);
 
-  client.request(program.path, request, response)
+  client.request(program.path, program.remote, request, response)
   .on('error', function(er) {
     return cb('Communication error (' + er.message + '), check master is listening');
   });

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,15 +7,17 @@ var ctl = require('./ctl');
 var debug = require('./debug');
 var toPipe = require('./pipe').toPipe;
 
+var remote_net = require('./client_ssh');
+
 // make a single request, response is passed to the callback, and the socket is
 // returned so it can be listened to for the 'error' event
-function client(addr, request, callback) {
+function client(addr, remote, request, callback) {
   addr = addr || ctl.ADDR;
   addr = toPipe(addr);
 
   debug('client - connect to', addr);
 
-  var sock = net.connect(addr, connect);
+  var sock = remote ? remote_net.connect(remote, addr, connect) : net.connect(addr, connect);
 
   function connect() {
     debug('client - send request', request);

--- a/lib/client_ssh.js
+++ b/lib/client_ssh.js
@@ -1,0 +1,36 @@
+var Connection = require('ssh2');
+
+function parseRemote(str) {
+  var parts = str.split('@');
+  return {
+    username: parts[0],
+    host: parts[1],
+    agent: process.env.SSH_AUTH_SOCK
+  };
+}
+
+function connect(remote, path, cb) {
+  var remote_pipe = [
+    process.execPath,
+    require.resolve('./stdio-pipe.js'), // PoC: assumes same path as local
+    path
+  ].join(' ');
+
+  var ssh = new Connection();
+
+  remote = parseRemote(remote);
+
+  ssh.on('ready', function() {
+    ssh.exec(remote_pipe, function(err, node) {
+      if (err) throw err;
+      cb.call(node);
+    });
+  });
+
+  ssh.connect(remote);
+
+  // acts enough like a socket for ./client.js
+  return ssh;
+}
+
+module.exports.connect = connect;

--- a/lib/stdio-pipe.js
+++ b/lib/stdio-pipe.js
@@ -1,0 +1,13 @@
+// Simple pipe connector
+
+var net = require('net');
+
+// Use last CLI argument as path to pipe/socket
+var addr = process.argv.pop();
+
+// Connect to pipe/socket
+var sock = net.connect(addr);
+
+// Connect socket to stdio
+sock.pipe(process.stdout);
+process.stdin.pipe(sock);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "commander": "~1.3.0",
     "debuglog": "~0.0.1",
     "rc": "~0.3.1",
-    "lodash": "~2.2.0"
+    "lodash": "~2.2.0",
+    "ssh2": "~0.2.17"
   },
   "devDependencies": {
     "mocha": "~1.9.0",


### PR DESCRIPTION
Simple proof-of-concept for using `clusterctl` on a control socket located on a remote host.

Adds a `-r,--remote` argument to `clusterctl` command that accepts a user@host. When a remote is given, the communication to the control socket is tunnelled through an ssh connection using the remote user name and host provided.

More for sharing than actual merging...

Launching the example-master:

``` sh
strong-cluster-control ryan$ cd bin && sl-run --cluster 2 example-master.js
strong-agent not profiling, configuration not found.
Generate configuration with:
    npm install -g strong-cli
    slc strongops
See http://docs.strongloop.com/strong-agent for more information.
supervisor starting (pid 54752)
supervisor size set to 2
supervisor listening on 'clusterctl'
supervisor started worker 1 (pid 54753)
supervisor started worker 2 (pid 54754)
supervisor resized to 2
cluster options: { clustered: 'worker', isMaster: false, isWorker: true }
worker id 1 pid 54753 example does no work... bye
cluster options: { clustered: 'worker', isMaster: false, isWorker: true }
worker id 2 pid 54754 example does no work... bye
```

Querying the cluster status on a "remote" host over ssh:

``` sh
strong-cluster-control ryan$ clusterctl -r ryan@localhost -p `pwd`/bin/clusterctl status
master pid: 54752
worker count: 2
worker id 1: { pid: 54753 }
worker id 2: { pid: 54754 }
```

Shutting down the "remote" cluster:

``` sh
Ryans-StrongMac:strong-cluster-control ryan$ clusterctl -r ryan@localhost -p `pwd`/bin/clusterctl stop
supervisor size set to 0
```

Meanwhile, back on the "server":

``` sh
supervisor stopped worker 2 (pid 54754)
supervisor worker id 2 (pid 54754) expected exit with 143
supervisor stopped worker 1 (pid 54753)
supervisor resized to 0
supervisor worker id 1 (pid 54753) expected exit with 143
supervisor size set to undefined
supervisor stopped
supervisor exiting with code 0
strong-cluster-control/bin ryan$ 
```
