### PR TITLE
Record & report start time of every process

### DIFF
--- a/api.md
+++ b/api.md
@@ -73,10 +73,11 @@ Returns the current cluster status. Its properties include:
 
  - `master`: {Object}
    - `pid`: The pid of the Master process.
- - `workers`: {Array} An Array of Objects containining the following properties:
+ - `workers`: {Array} An Array of Objects containing the following properties:
     - `id`: The id of the Worker within the Master.
     - `pid`: The pid of the Worker process.
     - `uptime`: The age of the Worker process in milliseconds.
+    - `startTime`: The time the Worker was started in milliseconds since epoh.
 
 ### control.setSize(N)
 

--- a/lib/master.js
+++ b/lib/master.js
@@ -350,6 +350,9 @@ function onFork(worker) {
   debug('master - on worker fork', worker.id);
   setupControl(worker.id);
   master._resize();
+  master.emit('fork', worker);
+  // emits on worker itself, _after_ it has been setup for control
+  worker.emit('fork');
 }
 
 function start(options, callback) {

--- a/lib/master.js
+++ b/lib/master.js
@@ -20,9 +20,9 @@ function clusterSize() {
 }
 
 var OPTION_DEFAULTS = {
-    shutdownTimeout: 5000,
-    terminateTimeout: 5000,
-    throttleDelay: 2000,
+  shutdownTimeout: 5000,
+  terminateTimeout: 5000,
+  throttleDelay: 2000,
 };
 
 master.status = status;

--- a/lib/master.js
+++ b/lib/master.js
@@ -39,6 +39,7 @@ master.start = start;
 master.stop = stop;
 master.CPUS = os.cpus().length;
 master.cmd = msg;
+master.startTime = Date.now();
 
 function status() {
   var retval = {};
@@ -46,6 +47,7 @@ function status() {
   retval.master = {
     pid: process.pid,
     setSize: this.size,
+    startTime: master.startTime,
   };
 
   retval.workers = [];
@@ -57,7 +59,8 @@ function status() {
     retval.workers.push({
       id: id,
       pid: w.process.pid,
-      uptime: now - w._control.birth,
+      uptime: now - w.startTime,
+      startTime: w.startTime,
     });
   }
 
@@ -212,9 +215,7 @@ function toWorker(id) {
   var worker = cluster.workers[id];
   assert(worker, 'worker id ' + id + ' invalid');
   worker._control = worker._control || {};
-  if (!worker._control.birth) {
-    worker._control.birth = Date.now();
-  }
+  worker.startTime = worker.startTime || Date.now();
   return worker;
 }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "debug": "^2.1.3",
-    "lodash": "^2.2.0"
+    "lodash": "^3.0.0"
   },
   "devDependencies": {
     "eslint": "^0.17.1",

--- a/test/master.js
+++ b/test/master.js
@@ -175,6 +175,22 @@ describe('master', function() {
     });
   });
 
+  describe('worker agumentations', function(done) {
+    it('should emit a "fork" event on workers', function(done) {
+      master.start(function() {
+        var worker = cluster.fork();
+        worker.once('fork', function() {
+          assert(_.isFinite(worker.startTime));
+          assert(_.isFinite(worker.process.pid));
+          worker.process.kill('SIGINT');
+        }).on('exit', function(code, signal) {
+          assert.equal(signal, 'SIGINT');
+          done();
+        });
+      });
+    });
+  });
+
   describe('should start', function() {
     describe('and stop', function() {
       it('notifying with events', function(done) {

--- a/test/master.js
+++ b/test/master.js
@@ -33,7 +33,7 @@ function pickWorker() {
 
 function assertWorker(worker) {
   var failures = [];
-  if (!_.isFinite(worker.id)) {
+  if (!_.isFinite(_.parseInt(worker.id, 10))) {
     failures.push('id invalid: ' + worker.id);
   }
   if (!_.isFinite(worker.pid) || worker.pid < 1) {

--- a/test/master.js
+++ b/test/master.js
@@ -42,8 +42,12 @@ function assertWorker(worker) {
   if (!_.isFinite(worker.uptime)) {
     failures.push('uptime invalid: ' + worker.uptime);
   }
+  if (!_.isFinite(worker.startTime)) {
+    failures.push('startTime invalid: ' + worker.startTime);
+  }
   if (failures.length > 0) {
-    assert.fail(worker, { id: 'present', pid: '> 0', uptime: '> 0'},
+    assert.fail(worker, {id: 'present', pid: '> 0', uptime: '> 0',
+                         startTime: 'valid'},
                 'Worker not valid: ' + util.inspect(worker, 0) +
                   ': ' + failures.join('\n'),
                '==');
@@ -75,6 +79,10 @@ describe('master', function() {
       assert.equal(master.CPUS, os.cpus().length);
     });
 
+    it('master process start time', function() {
+      assert(_.isFinite(master.startTime));
+    });
+
     it('message cmd names in master', function() {
       assert.equal(master.cmd.SHUTDOWN, 'CLUSTER_CONTROL_shutdown');
     });
@@ -94,6 +102,8 @@ describe('master', function() {
     it('for 0 workers', function() {
       var rsp = master.status();
       delete rsp.master.setSize;
+      assert(_.isFinite(rsp.master.startTime));
+      delete rsp.master.startTime;
       assert.equal(workerCount(), 0);
       assert.deepEqual(rsp, {master: {pid: process.pid}, workers:[]});
     });
@@ -130,6 +140,8 @@ describe('master', function() {
         cluster.disconnect(function() {
           var rsp = master.status();
           delete rsp.master.setSize;
+          assert(_.isFinite(rsp.master.startTime));
+          delete rsp.master.startTime;
           assert.deepEqual(rsp, {master:{pid: process.pid}, workers:[]});
           done();
         });
@@ -227,6 +239,7 @@ describe('master', function() {
         assert(worker);
         assert(worker.id);
         assert(worker.process.pid);
+        assert(_.isFinite(worker.startTime));
 
         sawNewWorker += 1;
 

--- a/test/require.js
+++ b/test/require.js
@@ -1,3 +1,4 @@
+var _ = require('lodash');
 var assert = require('assert');
 var control = require('../index');
 var master = require('../lib/master');
@@ -7,6 +8,10 @@ describe('require', function() {
     assert.equal(control.start, master.start);
     assert.equal(control.stop, master.stop);
     assert.equal(control.ADDR, master.ADDR);
+  });
+
+  it('should set the master process startTime', function() {
+    assert(_.isFinite(master.startTime));
   });
 
   it.skip('should expose null ops in slave', function() {


### PR DESCRIPTION
Once this is propagated up to PM it can be used to uniquely identify individual process using a tuple of (instanceId, pid, startTime), which should be safe for direct and docker runtimes.

Also:
 * upgrades lodash to 3.x (another point for strongloop/strongloop#213)
 * moves linting to pretest

/cc @kraman 