### PR TITLE
https://github.com/strongloop/strong-pm/issues/182

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -5,6 +5,7 @@
 var assert = require('assert');
 var cluster = require('cluster');
 var EventEmitter = require('events').EventEmitter;
+var nextTick = process.nextTick;
 var os = require('os');
 var util = require('util');
 var _ = require('lodash');
@@ -77,8 +78,8 @@ function setSize(size) {
 
   self.options.size = self.size = size;
 
-  process.nextTick(self.emit.bind(self, 'setSize', self.size));
-  process.nextTick(self._resize.bind(self));
+  nextTick(self.emit.bind(self, 'setSize', self.size));
+  nextTick(self._resize.bind(self));
 
   return self;
 }
@@ -197,17 +198,17 @@ function stopOne(callback) {
     debug('master - considering worker for stop', id, 'connected?', connected);
 
     if (connected) {
-      worker.once('exit', function(code, sig) {
-        debug('master - one worker stopped', this.id, 'code', code, 'sig', sig);
-        self.emit('stopWorker', worker, code, sig);
-        callback();
-      });
       self.shutdown(worker.id);
-      return;
     }
+    worker.once('exit', function(code, sig) {
+      debug('master - one worker stopped', this.id, 'code', code, 'sig', sig);
+      self.emit('stopWorker', worker, code, sig);
+      callback();
+    });
+    return;
   }
   debug('master - found no workers to stop');
-  process.nextTick(callback);
+  nextTick(callback);
 }
 
 // Return worker by id, ensuring it is annotated with an _control property.
@@ -287,14 +288,14 @@ function restart() {
 
   debug('master - restart:', self._restartIds);
 
-  process.nextTick(function() {
+  nextTick(function() {
     self.emit('startRestart', self._restartIds);
   });
 
   if (wasRestarting)
     return self;
 
-  process.nextTick(stopOneAfterResize);
+  nextTick(stopOneAfterResize);
 
   function stopOneAfterResize() {
     if (self._resizing) {
@@ -392,7 +393,7 @@ function start(options, callback) {
     self.once('start', callback);
   }
 
-  process.nextTick(function() {
+  nextTick(function() {
     self.emit('start');
   });
 
@@ -424,7 +425,7 @@ function stop(callback) {
     self.setSize(undefined);
     cluster.removeListener('exit', onExit);
     cluster.removeListener('fork', onFork);
-    process.nextTick(self.emit.bind(self, 'stop'));
+    nextTick(self.emit.bind(self, 'stop'));
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint . && jscs .",
-    "test": "mocha --reporter spec"
+    "test": "mocha --reporter spec",
+    "tap": "tap test/test-*.js"
   },
   "repository": {
     "type": "git",
@@ -36,7 +37,8 @@
   "devDependencies": {
     "eslint": "^0.17.1",
     "jscs": "^1.11.3",
-    "mocha": "^2.1.0"
+    "mocha": "^2.1.0",
+    "tap": "^0.7.1"
   },
   "engines": {
     "node": "*"

--- a/test/test-resize-disconnected.js
+++ b/test/test-resize-disconnected.js
@@ -1,0 +1,41 @@
+'use strict;'
+
+// Bail when run by mocha
+if ('describe' in global) {
+  describe(module.parent.filename, function() {
+    it.skip('run test with tap, not mocha', function(){});
+  });
+  return;
+}
+
+var cluster = require('cluster');
+var control = require('../');
+var fmt = require('util').format;
+
+if (cluster.isWorker) {
+  console.log('worker starting');
+  return;
+}
+
+control.start({size: 1});
+
+function summary() {
+  return Object.keys(cluster.workers).map(function(id) {
+    return fmt('%d:suicide=%j', id, cluster.workers[id].suicide);
+  }).join(' ');
+}
+
+function size() {
+  return Object.keys(cluster.workers).length;
+}
+
+control.on('resize', function() {
+  console.log('reached size: ', summary());
+  if (size() == 0) {
+    process.exit(0);
+  }
+  cluster.workers[1].disconnect();
+  console.log('disconnected:', summary());
+  control.setSize(0);
+  console.log('resizing:', summary());
+});


### PR DESCRIPTION
    Resize was assuming that there would always be a worker to disconnect,
    and busy-looping with nextTick if there was not.
    
    The state of having a cluster.worker that is disconnected is temporary,
    it will be removed once its exit status has been received. However, that
    status cannot be received if node is looping in next tick.
    
    On v0.10, this isn't noticed very often because nextTick is limited in
    how deep it will recurse before returning to the event loop. The only
    symptom would be a brief spike of ~100% CPU usage until the worker
    exits.
    
    On v0.12+, nextTick recursion is unlimited, so this can block
    indefinitely. Changing to setImmediate solves the indefinite problem,
    but still briefly busy loops.
    
    The fix is for stopOne() to wait for a worker that has already been
    disconnected to exit before continuing.

connected to strongloop-internal/scrum-nodeops#541