### PR TITLE
fix unintended change in worker order

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -181,9 +181,10 @@ function startOne(callback) {
 // shutdown the first worker that has not had .disconnect() called on it already
 function stopOne(callback) {
   var self = this;
-  // XXX(sam) picks by key order, semi random? should it sort by id, and
-  // disconnect the lowest? or sort by age, when I have it, and do the oldest?
-  var workerIds = liveWorkerIds();
+  // Inspect the workers in reverse order by id because it is the easiest to
+  // write tests against (worker 1 sticks around), even though it probably
+  // makes more sense to kill the oldest first.
+  var workerIds = liveWorkerIds().reverse();
   for (var i = 0; i < workerIds.length; i++) {
     var id = workerIds[i];
     var worker = cluster.workers[id];


### PR DESCRIPTION
The change in #54 causes strong-supervisor's tests to fail because it
assumes worker 1 sticks around but the new ordering resulted in worker
1 being the first to be 'resized'.

@sam-github this should fix strong-supervisor's failing builds on master.