### PR TITLE
status: preserve the cluster size during restart

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -44,7 +44,7 @@ function status() {
 
   retval.master = {
     pid: process.pid,
-    setSize: this.size,
+    setSize: this.options.size,
     startTime: master.startTime,
   };
 
@@ -67,15 +67,22 @@ function status() {
   return retval;
 }
 
-// TODO(schoon) - Check for valid size with `typeof`, et al or use `is2`.
-function setSize(size) {
+// cluster-control will set the size up and down in the process of restarting
+// the cluster. During this time, we want the 'advertised target size' of the
+// cluster to remain stable, since that is the size the cluster will be once the
+// restart is complete. If invisible is set, cluster will go to `size`, but that
+// size will not be stored in self.options.size, or returned by status().
+function setSize(size, invisible) {
   var self = this;
 
   debug('set size to %d from %d', size, self.size);
 
-  self.options.size = self.size = size;
+  self.size = size;
 
-  nextTick(self.emit.bind(self, 'setSize', self.size));
+  if (!invisible)
+    self.options.size = size;
+
+  nextTick(self.emit.bind(self, 'setSize', self.options.size));
   nextTick(self._resize.bind(self));
 
   return self;
@@ -106,7 +113,8 @@ function _startDelay(self) {
 function resize(worker) {
   var self = this;
 
-  debug('_resize: w? %s', worker ? worker.id : undefined);
+  if (worker)
+    debug('_resize: worker %s', worker.id);
 
   _recordSuicide(self, worker);
 
@@ -114,16 +122,16 @@ function resize(worker) {
     return self;
   }
 
-  var currentSize = clusterSize();
-
-  debug('resize to %d from %d resizing? %j',
-    self.size, currentSize, !!self._resizing);
-
   if (self._resizing) {
     // don't start doing multiple resizes in parallel, the events get listened
     // on by both sets, and get multi-counted
     return self;
   }
+
+  var currentSize = clusterSize();
+
+  debug('resize to %d from %d (apparent size %d)',
+        self.size, currentSize, self.options.size);
 
   self._resizing = true;
 
@@ -273,6 +281,10 @@ function terminate(id, shutdownWorker) {
   return master;
 }
 
+// Increase size (invisibly) to one past the current configured size. Once the
+// new worker has started, set the size back to the current configured size, the
+// oldest worker will be killed and the new one will remain. Repeat until all
+// old workers have been restarted.
 function restart() {
   var self = this;
   var wasRestarting = self._restartIds;
@@ -302,14 +314,14 @@ function restart() {
   }
 
   function startOne() {
-    self.setSize(self.options.size + 1);
+    self.setSize(self.options.size + 1, true);
 
     self.once('resize', stopOne);
   }
 
   function stopOne() {
     waitForStability(function() {
-      self.setSize(self.options.size - 1);
+      self.setSize(self.options.size);
       self.once('resize', _restart);
     });
   }
@@ -326,7 +338,7 @@ function restart() {
 
     function unstable() {
       var uptime = Date.now() - self._lastAbnormalExit;
-      var undersized = clusterSize() < self.options.size;
+      var undersized = clusterSize() < self.size;
       var unstable = undersized || uptime < self.options.throttleDelay;
       debug('unstable? %j undersized? %j uptime %d ms',
             unstable, undersized, uptime);

--- a/test/test-restart-ok.js
+++ b/test/test-restart-ok.js
@@ -17,8 +17,6 @@ tap.test('good workers are not killed', function(t) {
   var old;
   control.start({size: SIZE});
 
-  t.plan(1);
-
   control.once('resize', function() {
     debug('reached size, restart');
     control.restart();
@@ -35,6 +33,20 @@ tap.test('good workers are not killed', function(t) {
     debug('old %j fresh %j remaining: %j', old, fresh, remaining);
 
     t.equal(remaining.length, 0);
+    t.end();
+
+    cluster.removeListener('fork', checkStatus);
+    cluster.removeListener('exit', checkStatus);
+
     control.stop();
   });
+
+  cluster.on('fork', checkStatus);
+  cluster.on('exit', checkStatus);
+
+  function checkStatus() {
+    var status = control.status().master;
+    debug('status: %j', status);
+    t.equal(status.setSize, SIZE);
+  }
 });


### PR DESCRIPTION
cluster restart involves changing the cluster size as workers are
started and stopped. This was reflected in the status().master.setSize
output, but that's confusing to consumers of that data (such as arc)
because the size is changing all the time. Tracing is racy, it relies on
the assumption that the size doesn't change at critical times, if so, it
can get stuck. This reduces the prevalence of those races.

connected to strongloop-internal/scrum-nodeops#937

/cc @seanbrookes 